### PR TITLE
Updates to valiDrops

### DIFF
--- a/R/expression_filter.R
+++ b/R/expression_filter.R
@@ -60,7 +60,7 @@ expression_filter = function(stats, clusters, mito = 3, ribo = 3, min.significan
     x <- -log10(subset[, 8])
     threshold.significance.level <- median(x[y <= 0.4]) + (robustbase::Sn(x[y <= 0.4]) * 3)
     model <- lm(y ~ x)
-    model.significance.level <- segmented::segmented(model, npsi = 1, control = seg.control(quant = TRUE))$psi[2]
+    model.significance.level <- segmented::segmented(model, npsi = 1, control = segmented::seg.control(quant = TRUE))$psi[2]
     min.significance.level <- min(threshold.significance.level, model.significance.level, na.rm=TRUE)
   }
   

--- a/R/expression_filter.R
+++ b/R/expression_filter.R
@@ -60,7 +60,7 @@ expression_filter = function(stats, clusters, mito = 3, ribo = 3, min.significan
     x <- -log10(subset[, 8])
     threshold.significance.level <- median(x[y <= 0.4]) + (robustbase::Sn(x[y <= 0.4]) * 3)
     model <- lm(y ~ x)
-    model.significance.level <- segmented::segmented(model, npsi = 1, control = segmented::seg.control(quant = TRUE, tol = 1e-25))$psi[2]
+    model.significance.level <- segmented::segmented(model, npsi = 1, control = segmented::seg.control(quant = TRUE, tol = 1e-25, maxit.glm = 500, h = 0.05))$psi[2]
     min.significance.level <- min(threshold.significance.level, model.significance.level, na.rm=TRUE)
   }
   

--- a/R/expression_filter.R
+++ b/R/expression_filter.R
@@ -60,7 +60,7 @@ expression_filter = function(stats, clusters, mito = 3, ribo = 3, min.significan
     x <- -log10(subset[, 8])
     threshold.significance.level <- median(x[y <= 0.4]) + (robustbase::Sn(x[y <= 0.4]) * 3)
     model <- lm(y ~ x)
-    model.significance.level <- segmented::segmented(model, npsi = 1)$psi[2]
+    model.significance.level <- segmented::segmented(model, npsi = 1, control = seg.control(quant = TRUE))$psi[2]
     min.significance.level <- min(threshold.significance.level, model.significance.level, na.rm=TRUE)
   }
   

--- a/R/expression_filter.R
+++ b/R/expression_filter.R
@@ -60,7 +60,7 @@ expression_filter = function(stats, clusters, mito = 3, ribo = 3, min.significan
     x <- -log10(subset[, 8])
     threshold.significance.level <- median(x[y <= 0.4]) + (robustbase::Sn(x[y <= 0.4]) * 3)
     model <- lm(y ~ x)
-    model.significance.level <- segmented::segmented(model, npsi = 1, control = segmented::seg.control(quant = TRUE))$psi[2]
+    model.significance.level <- segmented::segmented(model, npsi = 1, control = segmented::seg.control(quant = TRUE, tol = 1e-25))$psi[2]
     min.significance.level <- min(threshold.significance.level, model.significance.level, na.rm=TRUE)
   }
   

--- a/R/expression_filter.R
+++ b/R/expression_filter.R
@@ -19,7 +19,7 @@
 #' @export
 
 #finding valid barcodes
-expression_filter = function(stats, clusters, mito = 3, ribo = 3, min.significant = 1, min.target.pct = 0.3, max.background.pct = 0.7, min.diff.pct = 0.2, min.de.frac = 0.01, min.significance.level = NULL, plot = FALSE) {
+expression_filter = function(stats, clusters, mito = 3, ribo = 3, min.significant = 1, min.target.pct = 0.3, max.background.pct = 0.7, min.diff.pct = 0.2, min.de.frac = 0.01, min.significance.level = NULL, plot = FALSE, tol = 1e-50, maxit.glm = 2500, h = 0.01) {
   ## evaluate arguments
   # min.significant argument
   if(class(min.significant) != "numeric" | min.significant < 0) stop('min.significant needs to be a numeric greater than or equal to 0', call. = FALSE)
@@ -54,7 +54,7 @@ expression_filter = function(stats, clusters, mito = 3, ribo = 3, min.significan
   if(class(plot) != "logical") stop('plot needs to be a boolean (TRUE or FALSE)', call. = FALSE)
 
   # model function to return error if necessary
-  model.significance.level.function <- function(model){result <- tryCatch({segmented::segmented(model, npsi = 1, control = segmented::seg.control(quant = TRUE, tol = 1e-25, maxit.glm = 500, h = 0.05))$psi[2]}, error = function(e){NA})}
+  model.significance.level.function <- function(model){result <- tryCatch({segmented::segmented(model, npsi = 1, control = segmented::seg.control(quant = TRUE, tol = tol, maxit.glm = maxit.glm, h = h))$psi[2]}, error = function(e){NA})}
   
   # Find threshold on significance level
   if (is.null(min.significance.level)) {

--- a/R/expression_metrics.R
+++ b/R/expression_metrics.R
@@ -92,7 +92,17 @@ expression_metrics = function(counts, mito, ribo, nfeats = 5000, npcs = 10, k.mi
   ### Clustering
   ## Shallow
   clusters.shallow <- Seurat::FindClusters(snn, verbose=F, res=res.shallow)
-  
+  if(length(unique(clusters.shallow[,1])) == 1){
+	  stop = 0
+	  while(stop == 0){
+		  res.shallow = res.shallow + 0.1
+		  clusters.shallow <- Seurat::FindClusters(snn, verbose=F, res=res.shallow)
+		  if(length(unique(clusters.shallow[,1])) > 1){
+			  stop = 1
+		  }
+	  }
+  }
+
   ## Deep
   # Coarse clustering and processing
   clusters.deep <- Seurat::FindClusters(snn, verbose=F, res=seq(1,20, by = 1))

--- a/R/expression_metrics.R
+++ b/R/expression_metrics.R
@@ -105,7 +105,23 @@ expression_metrics = function(counts, mito, ribo, nfeats = 5000, npcs = 10, k.mi
 
   ## Deep
   # Coarse clustering and processing
-  clusters.deep <- Seurat::FindClusters(snn, verbose=F, res=seq(1,20, by = 1))
+  clusters.deep <- as.data.frame(matrix(nrow = length(snn@Dimnames[[1]]), ncol = 20, dimnames = list(snn@Dimnames[[1]], NULL)))
+  fails <- numeric(20)
+  for(i in 1:20){
+	  tryCatch(clusters.deep[,i] <- Seurat::FindClusters(snn, verbose=F, res=i),
+		   error = function(e) {
+			   message(paste0("Limiting deep clustering resolution to ", i))
+			   fails[i] <<- 1
+		   })
+	  if(fails[i] == 1){
+		  break()
+	  }
+  }
+  if(is.element(1, fails)){
+	  clusters.deep <- Seurat::FindClusters(snn, verbose=F, res=seq(1,(match(1, fails) - 1),by=(match(1, fails) - 1)/20))
+  } else{
+	  clusters.deep <- Seurat::FindClusters(snn, verbose=F, res=seq(1,20,by=1))
+  }
   mins <- apply(clusters.deep,2,FUN=function(x) { min(table(x))})
   closest <- min(abs(mins - k.min))
   close.res <- as.numeric(substr(names(which(abs(mins - k.min) == closest)),5,100))

--- a/R/quality_filter.R
+++ b/R/quality_filter.R
@@ -23,7 +23,7 @@
 #' @import robustbase
 #' @import segmented
 
-quality_filter = function(metrics, mito = TRUE, distance = TRUE, coding = TRUE, contrast = FALSE, mito.nreps = 10, mito.max = 0.3, npsi = 3, dist.threshold = 5, coding.threshold = 3, contrast.threshold = 3, plot = TRUE) {
+quality_filter = function(metrics, mito = TRUE, distance = TRUE, coding = TRUE, contrast = FALSE, mito.nreps = 10, mito.max = 0.3, npsi = 3, dist.threshold = 5, coding.threshold = 3, contrast.threshold = 3, plot = TRUE, tol = 1e-50, maxit.glm = 2500, h = 0.01) {
   ## evaluate arguments
   # metrics matrix
   if(missing(metrics)) { stop('No metrics data frame was provided', call. = FALSE) }
@@ -84,11 +84,11 @@ quality_filter = function(metrics, mito = TRUE, distance = TRUE, coding = TRUE, 
         stop <- 0
         metrics.subsample <- metrics[ sample(1:nrow(metrics), sample.size),]
         model <- lm(logFeatures ~ mitochondrial_fraction, data = metrics.subsample)
-        seg <- segmented::segmented(model, npsi = psi, control = segmented::seg.control(quant = TRUE, tol = 1e-25, maxit.glm = 500, h = 0.05))
+        seg <- segmented::segmented(model, npsi = psi, control = segmented::seg.control(quant = TRUE, tol = tol, maxit.glm = maxit.glm, h = h))
         if (min(seg$psi[,2]) > mito.max) { stop <- 1 }
           while (stop == 1) {
             psi <- psi + 1
-            seg <- segmented::segmented(model, npsi = psi, control = segmented::seg.control(quant = TRUE, tol = 1e-25, maxit.glm = 500, h = 0.05))
+            seg <- segmented::segmented(model, npsi = psi, control = segmented::seg.control(quant = TRUE, tol = tol, maxit.glm = maxit.glm, h = h))
             if (psi >= 5 | min(seg$psi[,2]) <= mito.max) { stop <- 0 }
           }		
           mito.thresholds <- c(mito.thresholds, min(seg$psi[,2]))
@@ -124,7 +124,7 @@ quality_filter = function(metrics, mito = TRUE, distance = TRUE, coding = TRUE, 
       # Segmented model
       model <- lm(logFeatures ~ logUMIs, data = metrics)
       while (floor(npsi) >= 1) {
-	out <- suppressWarnings(segmented::segmented(model, npsi = floor(npsi), control = segmented::seg.control(quant = TRUE, tol = 1e-25, maxit.glm = 500, h = 0.05)))
+	out <- suppressWarnings(segmented::segmented(model, npsi = floor(npsi), control = segmented::seg.control(quant = TRUE, tol = tol, maxit.glm = maxit.glm, h = h)))
 	if (class(out)[1] == "segmented") {
 	  break
 	} else {

--- a/R/quality_filter.R
+++ b/R/quality_filter.R
@@ -84,11 +84,11 @@ quality_filter = function(metrics, mito = TRUE, distance = TRUE, coding = TRUE, 
         stop <- 0
         metrics.subsample <- metrics[ sample(1:nrow(metrics), sample.size),]
         model <- lm(logFeatures ~ mitochondrial_fraction, data = metrics.subsample)
-        seg <- segmented::segmented(model, npsi = psi)
+        seg <- segmented::segmented(model, npsi = psi, control = seg.control(QUANT = TRUE))
         if (min(seg$psi[,2]) > mito.max) { stop <- 1 }
           while (stop == 1) {
             psi <- psi + 1
-            seg <- segmented::segmented(model, npsi = psi)
+            seg <- segmented::segmented(model, npsi = psi, control = seg.control(QUANT = TRUE))
             if (psi >= 5 | min(seg$psi[,2]) <= mito.max) { stop <- 0 }
           }		
           mito.thresholds <- c(mito.thresholds, min(seg$psi[,2]))
@@ -124,7 +124,7 @@ quality_filter = function(metrics, mito = TRUE, distance = TRUE, coding = TRUE, 
       # Segmented model
       model <- lm(logFeatures ~ logUMIs, data = metrics)
       while (floor(npsi) >= 1) {
-	out <- suppressWarnings(segmented::segmented(model, npsi = floor(npsi)))
+	out <- suppressWarnings(segmented::segmented(model, npsi = floor(npsi), control = seg.control(QUANT = TRUE)))
 	if (class(out)[1] == "segmented") {
 	  break
 	} else {

--- a/R/quality_filter.R
+++ b/R/quality_filter.R
@@ -84,11 +84,11 @@ quality_filter = function(metrics, mito = TRUE, distance = TRUE, coding = TRUE, 
         stop <- 0
         metrics.subsample <- metrics[ sample(1:nrow(metrics), sample.size),]
         model <- lm(logFeatures ~ mitochondrial_fraction, data = metrics.subsample)
-        seg <- segmented::segmented(model, npsi = psi, control = seg.control(quant = TRUE))
+        seg <- segmented::segmented(model, npsi = psi, control = segmented::seg.control(quant = TRUE))
         if (min(seg$psi[,2]) > mito.max) { stop <- 1 }
           while (stop == 1) {
             psi <- psi + 1
-            seg <- segmented::segmented(model, npsi = psi, control = seg.control(quant = TRUE))
+            seg <- segmented::segmented(model, npsi = psi, control = segmented::seg.control(quant = TRUE))
             if (psi >= 5 | min(seg$psi[,2]) <= mito.max) { stop <- 0 }
           }		
           mito.thresholds <- c(mito.thresholds, min(seg$psi[,2]))
@@ -124,7 +124,7 @@ quality_filter = function(metrics, mito = TRUE, distance = TRUE, coding = TRUE, 
       # Segmented model
       model <- lm(logFeatures ~ logUMIs, data = metrics)
       while (floor(npsi) >= 1) {
-	out <- suppressWarnings(segmented::segmented(model, npsi = floor(npsi), control = seg.control(quant = TRUE)))
+	out <- suppressWarnings(segmented::segmented(model, npsi = floor(npsi), control = segmented::seg.control(quant = TRUE)))
 	if (class(out)[1] == "segmented") {
 	  break
 	} else {

--- a/R/quality_filter.R
+++ b/R/quality_filter.R
@@ -84,11 +84,11 @@ quality_filter = function(metrics, mito = TRUE, distance = TRUE, coding = TRUE, 
         stop <- 0
         metrics.subsample <- metrics[ sample(1:nrow(metrics), sample.size),]
         model <- lm(logFeatures ~ mitochondrial_fraction, data = metrics.subsample)
-        seg <- segmented::segmented(model, npsi = psi, control = segmented::seg.control(quant = TRUE, tol = 1e-25))
+        seg <- segmented::segmented(model, npsi = psi, control = segmented::seg.control(quant = TRUE, tol = 1e-25, maxit.glm = 500, h = 0.05))
         if (min(seg$psi[,2]) > mito.max) { stop <- 1 }
           while (stop == 1) {
             psi <- psi + 1
-            seg <- segmented::segmented(model, npsi = psi, control = segmented::seg.control(quant = TRUE, tol = 1e-25))
+            seg <- segmented::segmented(model, npsi = psi, control = segmented::seg.control(quant = TRUE, tol = 1e-25, maxit.glm = 500, h = 0.05))
             if (psi >= 5 | min(seg$psi[,2]) <= mito.max) { stop <- 0 }
           }		
           mito.thresholds <- c(mito.thresholds, min(seg$psi[,2]))
@@ -124,7 +124,7 @@ quality_filter = function(metrics, mito = TRUE, distance = TRUE, coding = TRUE, 
       # Segmented model
       model <- lm(logFeatures ~ logUMIs, data = metrics)
       while (floor(npsi) >= 1) {
-	out <- suppressWarnings(segmented::segmented(model, npsi = floor(npsi), control = segmented::seg.control(quant = TRUE, tol = 1e-25)))
+	out <- suppressWarnings(segmented::segmented(model, npsi = floor(npsi), control = segmented::seg.control(quant = TRUE, tol = 1e-25, maxit.glm = 500, h = 0.05)))
 	if (class(out)[1] == "segmented") {
 	  break
 	} else {

--- a/R/quality_filter.R
+++ b/R/quality_filter.R
@@ -84,11 +84,11 @@ quality_filter = function(metrics, mito = TRUE, distance = TRUE, coding = TRUE, 
         stop <- 0
         metrics.subsample <- metrics[ sample(1:nrow(metrics), sample.size),]
         model <- lm(logFeatures ~ mitochondrial_fraction, data = metrics.subsample)
-        seg <- segmented::segmented(model, npsi = psi, control = segmented::seg.control(quant = TRUE))
+        seg <- segmented::segmented(model, npsi = psi, control = segmented::seg.control(quant = TRUE, tol = 1e-25))
         if (min(seg$psi[,2]) > mito.max) { stop <- 1 }
           while (stop == 1) {
             psi <- psi + 1
-            seg <- segmented::segmented(model, npsi = psi, control = segmented::seg.control(quant = TRUE))
+            seg <- segmented::segmented(model, npsi = psi, control = segmented::seg.control(quant = TRUE, tol = 1e-25))
             if (psi >= 5 | min(seg$psi[,2]) <= mito.max) { stop <- 0 }
           }		
           mito.thresholds <- c(mito.thresholds, min(seg$psi[,2]))
@@ -124,7 +124,7 @@ quality_filter = function(metrics, mito = TRUE, distance = TRUE, coding = TRUE, 
       # Segmented model
       model <- lm(logFeatures ~ logUMIs, data = metrics)
       while (floor(npsi) >= 1) {
-	out <- suppressWarnings(segmented::segmented(model, npsi = floor(npsi), control = segmented::seg.control(quant = TRUE)))
+	out <- suppressWarnings(segmented::segmented(model, npsi = floor(npsi), control = segmented::seg.control(quant = TRUE, tol = 1e-25)))
 	if (class(out)[1] == "segmented") {
 	  break
 	} else {

--- a/R/quality_filter.R
+++ b/R/quality_filter.R
@@ -84,11 +84,11 @@ quality_filter = function(metrics, mito = TRUE, distance = TRUE, coding = TRUE, 
         stop <- 0
         metrics.subsample <- metrics[ sample(1:nrow(metrics), sample.size),]
         model <- lm(logFeatures ~ mitochondrial_fraction, data = metrics.subsample)
-        seg <- segmented::segmented(model, npsi = psi, control = seg.control(QUANT = TRUE))
+        seg <- segmented::segmented(model, npsi = psi, control = seg.control(quant = TRUE))
         if (min(seg$psi[,2]) > mito.max) { stop <- 1 }
           while (stop == 1) {
             psi <- psi + 1
-            seg <- segmented::segmented(model, npsi = psi, control = seg.control(QUANT = TRUE))
+            seg <- segmented::segmented(model, npsi = psi, control = seg.control(quant = TRUE))
             if (psi >= 5 | min(seg$psi[,2]) <= mito.max) { stop <- 0 }
           }		
           mito.thresholds <- c(mito.thresholds, min(seg$psi[,2]))
@@ -124,7 +124,7 @@ quality_filter = function(metrics, mito = TRUE, distance = TRUE, coding = TRUE, 
       # Segmented model
       model <- lm(logFeatures ~ logUMIs, data = metrics)
       while (floor(npsi) >= 1) {
-	out <- suppressWarnings(segmented::segmented(model, npsi = floor(npsi), control = seg.control(QUANT = TRUE)))
+	out <- suppressWarnings(segmented::segmented(model, npsi = floor(npsi), control = seg.control(quant = TRUE)))
 	if (class(out)[1] == "segmented") {
 	  break
 	} else {

--- a/R/rank_barcodes.R
+++ b/R/rank_barcodes.R
@@ -98,7 +98,7 @@ rank_barcodes = function(counts, type = "UMI", psi.min = 2, psi.max = 5, alpha =
       rmse[counter,3] <- counter
       models[[counter]] <- out
       counter <- counter + 1
-    } else if (any(grepl("psi values too close", out[[1]]))) {
+    } else if (any(grepl("psi starting values too close", out[[1]]))) {
 		  stop = 0
 		  while (stop == 0) {
 			  curr.alpha <- curr.alpha + alpha

--- a/R/valiDrops.R
+++ b/R/valiDrops.R
@@ -78,7 +78,7 @@ valiDrops = function(counts, rank_barcodes = TRUE, status = TRUE, stageThree = T
   ## Run rank_barcodes
   if (rank_barcodes) {
     if (status) { message("Step 1: Filtering on the barcode-rank plot.")}
-    threshold <- valiDrops::rank_barcodes(counts = counts, type = type, psi.min = psi.min, psi.max = psi.max, alpha = alpha, alpha.max = alpha.max, boot = boot, factor = factor, threshold = threshold, plot = plot))
+    threshold <- valiDrops::rank_barcodes(counts = counts, type = type, psi.min = psi.min, psi.max = psi.max, alpha = alpha, alpha.max = alpha.max, boot = boot, factor = factor, threshold = threshold, plot = plot)
     rank.pass <- rownames(threshold$ranks[ threshold$ranks$counts >= threshold$lower.threshold,])
   } else {
     if (status) { message("Step 1: Removing barcodes with zero counts.")}
@@ -99,7 +99,7 @@ valiDrops = function(counts, rank_barcodes = TRUE, status = TRUE, stageThree = T
   
   ## Run quality_filter
   if (status) { message("Step 3: Filtering on quality metrics.")}
-  qc.pass <- valiDrops::quality_filter(metrics = metrics$metrics, mito = mitol, distance = distancel, coding = codingl, contrast = contrastl, mito.nreps = mito.nreps, mito.max = mito.max, npsi = npsi, dist.threshold = dist.threshold, coding.threshold = coding.threshold, contrast.threshold = contrast.threshold, plot = plot))
+  qc.pass <- valiDrops::quality_filter(metrics = metrics$metrics, mito = mitol, distance = distancel, coding = codingl, contrast = contrastl, mito.nreps = mito.nreps, mito.max = mito.max, npsi = npsi, dist.threshold = dist.threshold, coding.threshold = coding.threshold, contrast.threshold = contrast.threshold, plot = plot)
   
   if (stageThree) {
     ## Convert counts to Seurat capatible format
@@ -110,11 +110,11 @@ valiDrops = function(counts, rank_barcodes = TRUE, status = TRUE, stageThree = T
     }
 
     ## Run expression_matrix
-    expr.metrics <- valiDrops::expression_metrics(counts = counts.subset.filtered, mito = metrics$mitochondrial, ribo = metrics$ribosomal, nfeats = nfeats, npcs = min(npcs, ncol(counts.subset.filtered)), k.min = k.min, res.shallow = res.shallow, top.n = top.n))
+    expr.metrics <- valiDrops::expression_metrics(counts = counts.subset.filtered, mito = metrics$mitochondrial, ribo = metrics$ribosomal, nfeats = nfeats, npcs = min(npcs, ncol(counts.subset.filtered)), k.min = k.min, res.shallow = res.shallow, top.n = top.n)
     
     ## Run expression_filter
     if (status) { message("Step 5: Filtering on expression-based metrics.")}
-    valid <- valiDrops::expression_filter(stats = expr.metrics$stats, clusters = expr.metrics$clusters, mito = mitochondrial_clusters, ribo = ribosomal_clusters, min.significant = min.significant, min.target.pct = min.target.pct, max.background.pct = max.background.pct, min.diff.pct = min.diff.pct, min.de.frac = min.de.frac, min.significance.level = min.significance.level, plot = plot))
+    valid <- valiDrops::expression_filter(stats = expr.metrics$stats, clusters = expr.metrics$clusters, mito = mitochondrial_clusters, ribo = ribosomal_clusters, min.significant = min.significant, min.target.pct = min.target.pct, max.background.pct = max.background.pct, min.diff.pct = min.diff.pct, min.de.frac = min.de.frac, min.significance.level = min.significance.level, plot = plot)
   } else {
     valid <- qc.pass$final
   }

--- a/R/valiDrops.R
+++ b/R/valiDrops.R
@@ -18,7 +18,7 @@
 #' @import Seurat
 #' @import SingleCellExperiment
 
-valiDrops = function(counts, rank_barcodes = TRUE, status = TRUE, stageThree = TRUE, label_dead = FALSE, plot = TRUE, verbose = TRUE,
+valiDrops = function(counts, rank_barcodes = TRUE, status = TRUE, stageThree = TRUE, label_dead = FALSE, plot = TRUE, verbose = TRUE, tol = 1e-50, maxit.glm = 2500, h = 0.01,
                     type = "UMI", psi.min = 2, psi.max = 5, alpha = 0.001, alpha.max = 0.05, boot = 10, factor = 1.5, threshold = TRUE,
                     contrast = NULL, contrast_type = "denominator", species = "auto", annotation = "auto", mito = "auto", ribo = "auto", coding = "auto",
                     mitol = TRUE, distancel = TRUE, codingl = TRUE, contrastl = FALSE, mito.nreps = 10, mito.max = 0.3, npsi = 3, dist.threshold = 5, coding.threshold = 3, contrast.threshold = 3,
@@ -99,7 +99,7 @@ valiDrops = function(counts, rank_barcodes = TRUE, status = TRUE, stageThree = T
   
   ## Run quality_filter
   if (status) { message("Step 3: Filtering on quality metrics.")}
-  qc.pass <- valiDrops::quality_filter(metrics = metrics$metrics, mito = mitol, distance = distancel, coding = codingl, contrast = contrastl, mito.nreps = mito.nreps, mito.max = mito.max, npsi = npsi, dist.threshold = dist.threshold, coding.threshold = coding.threshold, contrast.threshold = contrast.threshold, plot = plot)
+  qc.pass <- valiDrops::quality_filter(metrics = metrics$metrics, mito = mitol, distance = distancel, coding = codingl, contrast = contrastl, mito.nreps = mito.nreps, mito.max = mito.max, npsi = npsi, dist.threshold = dist.threshold, coding.threshold = coding.threshold, contrast.threshold = contrast.threshold, plot = plot, tol = tol, maxit.glm = maxit.glm, h = h)
   
   if (stageThree) {
     ## Convert counts to Seurat capatible format
@@ -114,7 +114,7 @@ valiDrops = function(counts, rank_barcodes = TRUE, status = TRUE, stageThree = T
     
     ## Run expression_filter
     if (status) { message("Step 5: Filtering on expression-based metrics.")}
-    valid <- valiDrops::expression_filter(stats = expr.metrics$stats, clusters = expr.metrics$clusters, mito = mitochondrial_clusters, ribo = ribosomal_clusters, min.significant = min.significant, min.target.pct = min.target.pct, max.background.pct = max.background.pct, min.diff.pct = min.diff.pct, min.de.frac = min.de.frac, min.significance.level = min.significance.level, plot = plot)
+    valid <- valiDrops::expression_filter(stats = expr.metrics$stats, clusters = expr.metrics$clusters, mito = mitochondrial_clusters, ribo = ribosomal_clusters, min.significant = min.significant, min.target.pct = min.target.pct, max.background.pct = max.background.pct, min.diff.pct = min.diff.pct, min.de.frac = min.de.frac, min.significance.level = min.significance.level, plot = plot, tol = tol, maxit.glm = maxit.glm, h = h)
   } else {
     valid <- qc.pass$final
   }

--- a/R/valiDrops.R
+++ b/R/valiDrops.R
@@ -108,6 +108,7 @@ valiDrops = function(counts, filtered_counts = NULL, rank_barcodes = TRUE, statu
     to_continue <- readline(prompt = "More than twice as many cells detected than in the filtered matrix. Type [Y] if you would like to continue and [N] if not: ")
     if(to_continue %in% c("N", "No", "n", "no")){
       stop("Pipeline terminated by user. Please try again on filtered counts and skip barcode ranking.")
+    }
   }
   
   if (stageThree) {

--- a/R/valiDrops.R
+++ b/R/valiDrops.R
@@ -104,13 +104,15 @@ valiDrops = function(counts, filtered_counts = NULL, rank_barcodes = TRUE, statu
   qc.pass <- R.utils::withTimeout({valiDrops::quality_filter(metrics = metrics$metrics, mito = mitol, distance = distancel, coding = codingl, contrast = contrastl, mito.nreps = mito.nreps, mito.max = mito.max, npsi = npsi, dist.threshold = dist.threshold, coding.threshold = coding.threshold, contrast.threshold = contrast.threshold, plot = plot, tol = tol, maxit.glm = maxit.glm, h = h)},
                                    timeout = timeout,
                                    onTimeout = "error")
-  if(!is.null(filtered_counts) & length(qc.pass$final) >= 2*ncol(filtered_counts)){
-    to_continue <- readline(prompt = "More than twice as many cells detected than in the filtered matrix. Type [Y] if you would like to continue and [N] if not: ")
-    if(to_continue %in% c("N", "No", "n", "no")){
-      stop("Pipeline terminated by user. Please try again on filtered counts and skip barcode ranking.")
+  if(!is.null(filtered_counts)){
+    if(length(qc.pass$final) >= 2*ncol(filtered_counts)){
+      to_continue <- readline(prompt = "More than twice as many cells detected than in the filtered matrix. Type [Y] if you would like to continue and [N] if not: ")
+      if(to_continue %in% c("N", "No", "n", "no")){
+        stop("Pipeline terminated by user. Please try again on filtered counts and skip barcode ranking.")
+      }
     }
   }
-  
+      
   if (stageThree) {
     ## Convert counts to Seurat capatible format
     if (status) { message("Step 4: Collecting expression-based metrics.")}


### PR DESCRIPTION
- Fixes breakpoint error typo when ranking barcodes
- Allows autocalculation of segmentation parameters with seg.control function
- Permits modification of values for h, maxit.glm, and tol within seg.control function for all steps of pipeline
- Fixes rare error on expression metric calculation by limiting deep clustering resolutions if necessary
- Added optional time limit for each stage of pipeline
- Allows user to terminate pipeline if more than twice as many barcodes are retained after ranking and QC filtering (prior to calculating expression characteristics) as in the default filtered matrix generated by alignment software, e.g., Cellranger, CeleScope, etc.